### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author= ROBERT BOSCH GMBH
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows to use the IMU MKR Shield
 paragraph=Allows to use the IMU MKR Shield
-category=Sensor
+category=Sensors
 url=http://www.arduino.cc/en/Reference/
 architectures=samd


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Sensor' in library BNO055 is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format